### PR TITLE
fix: errors in some API resources weren't being propagated

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -150,6 +150,11 @@ func (c *Client) ReadTeam(t broker.Team) (*broker.Team, error) {
 // CreateTeam creates a Team
 func (c *Client) CreateTeam(t broker.TeamCreateOrUpdateRequest) (*broker.Team, error) {
 	res, err := c.doCrud("POST", teamCreateTemplate, t, new(broker.TeamsResponse))
+
+	if err != nil {
+		return nil, err
+	}
+
 	apiResponse := res.(*broker.TeamsResponse)
 
 	// TODO: why is this a collection not a single resource?
@@ -166,14 +171,17 @@ func (c *Client) CreateTeam(t broker.TeamCreateOrUpdateRequest) (*broker.Team, e
 // ReadTeamAssignments finds all users currently in a team
 func (c *Client) ReadTeamAssignments(t broker.Team) (*broker.TeamsAssignmentResponse, error) {
 	res, err := c.doCrud("GET", urlEncodeTemplate(teamAssignmentTemplate, t.UUID), t, new(broker.TeamsAssignmentResponse))
-	apiResponse := res.(*broker.TeamsAssignmentResponse)
-
-	return apiResponse, err
+	return res.(*broker.TeamsAssignmentResponse), err
 }
 
 // UpdateTeamAssignments sets the users for a given team, removing any existing users not in the specified request
 func (c *Client) UpdateTeamAssignments(r broker.TeamsAssignmentRequest) (*broker.TeamsAssignmentResponse, error) {
 	res, err := c.doCrud("PUT", urlEncodeTemplate(teamAssignmentTemplate, r.UUID), r, new(broker.TeamsAssignmentResponse))
+
+	if err != nil {
+		return nil, err
+	}
+
 	if len(r.Users) > 0 {
 		apiResponse := res.(*broker.TeamsAssignmentResponse)
 
@@ -186,6 +194,11 @@ func (c *Client) UpdateTeamAssignments(r broker.TeamsAssignmentRequest) (*broker
 // AppendTeamAssignments adds users to an existing Team (does not remove absent ones)
 func (c *Client) AppendTeamAssignments(r broker.TeamsAssignmentRequest) (*broker.TeamsAssignmentResponse, error) {
 	res, err := c.doCrud("POST", urlEncodeTemplate(teamAssignmentTemplate, r.UUID), r, new(broker.TeamsAssignmentResponse))
+
+	if err != nil {
+		return nil, err
+	}
+
 	if len(r.Users) > 0 {
 		apiResponse := res.(*broker.TeamsAssignmentResponse)
 
@@ -268,6 +281,10 @@ func (c *Client) CreateUser(u broker.User) (*broker.User, error) {
 // CreateUser creates a user or a system account
 func (c *Client) CreateSystemAccount(u broker.User) (*broker.User, error) {
 	res, err := c.doCrud("POST", systemAccountCreateTemplate, u, nil)
+
+	if err != nil {
+		return nil, err
+	}
 
 	// Returns a 201
 	// e.g. https://tf-acceptance.pactflow.io/admin/system-accounts/f996d7e5-6525-4649-b479-9299793d105e

--- a/client/errors.go
+++ b/client/errors.go
@@ -11,7 +11,7 @@ type apiErrorDescriptions []string
 
 type APIKeyedError map[apiErrorKey]apiErrorDescriptions
 
-// apiErrorResponse represents a body of the shape: {"errors":{"parameter": ["parameter is invaled"]}}
+// apiErrorResponse represents a body of the shape: {"errors":{"parameter": ["parameter is invalid"]}}
 type apiErrorResponse struct {
 	Errors       APIKeyedError   `json:"errors"`
 	Reference    string          `json:"reference"`


### PR DESCRIPTION
Fix for the following fatal error:
```
2023-03-17T00:04:04.601Z [DEBUG] plugin.terraform-provider-pact: 2023/03/17 00:04:04 [DEBUG] response for request: &{POST https://xyz.pactflow.io/admin/system-accounts HTTP/1.1 1 1 map[Accept:[application/hal+json, application/json] Authorization:[Bearer AATaTzDgZmrxyj9WyAwCkg] Content-Type:[application/json] User-Agent:[go-pact/v0.9.0]] {} 0x82df20 118 [] false xyz.pactflow.io map[] map[] <nil> map[]   <nil> <nil> <nil> 0xc00011e000} resp: &{400 Bad Request 400 HTTP/2.0 2 0 map[Content-Length:[85] Content-Type:[application/hal+json;charset=utf-8] Date:[Fri, 17 Mar 2023 00:04:04 GMT] Server:[Webmachine-Ruby/1.6.0 Rack/1.3] Strict-Transport-Security:[max-age=63072000; includeSubDomains; preload] Vary:[Accept] X-Content-Type-Options:[nosniff] X-Pact-Broker-Git-Sha:[e0c525cf] X-Pact-Broker-Version:[2.106.0] X-Pactflow-Git-Sha:[5cad6c1c4] X-Request-Id:[203cdc79be070b6f06af25cef6ff80e2]] {0xc000621e00} 85 [] false false map[] 0xc0001a6700 0xc00085a0b0}
2023-03-17T00:04:04.601Z [DEBUG] plugin.terraform-provider-pact: 2023/03/17 00:04:04 [DEBUG] handling error response: {"errors":{"name":["A system account with name 'Bender Rodríguez' already exists"]}}
panic: interface conversion: interface {} is nil, not string
```

The error is now properly bubbled back up to the user:

<img width="649" alt="Screen Shot 2023-03-17 at 12 08 24 pm" src="https://user-images.githubusercontent.com/53900/225786732-e68ecb66-60ce-473b-a1b0-58bafb97945a.png">
