### PR TITLE
chore: fix pact test for system account

### DIFF
--- a/client/client_pact_test.go
+++ b/client/client_pact_test.go
@@ -739,14 +739,15 @@ func TestTerraformClientPact(t *testing.T) {
 				WithHeader("Authorization", Like("Bearer 1234")).
 				WithJSONBody(Like(user)).
 				WillRespondWith(201).
-				WithHeader("Content-Type", S("application/hal+json"))
+				WithHeader("Content-Type", S("application/hal+json")).
+				WithHeader("Location", S(created.UUID))
 
 			err = mockProvider.ExecuteTest(t, func(config MockServerConfig) error {
 				client := clientForPact(config)
 
 				res, e := client.CreateSystemAccount(user)
 				assert.NoError(t, e)
-				assert.Equal(t, "system account", res.Name)
+				assert.Equal(t, created.UUID, res.UUID)
 
 				return e
 			})


### PR DESCRIPTION
The system account creation uses the `Location` header to extract the user's UUID. This was missing in the pact test, but was not apparent because the assertion checked a value that was guaranteed to be correct (a value that was not extracted from the HTTP request). The only value that is dynamic from the HTTP test was the UUID, which was not covered by the test. 

This change addresses the gap.