### PR TITLE
PACT-6767: Replace tags with branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ publish:
 	@echo "--- 🤝 Transforming Broken Keys in Pact File"
 	"$(PWD)/scripts/transform-broken-keys.sh"
 	@echo "--- 🤝 Publishing Pact"
-	"${PACT_CLI}" publish ${PWD}/client/pacts --consumer-app-version ${GITHUB_SHA} --tag ${GITHUB_BRANCH}
+	"${PACT_CLI}" publish ${PWD}/client/pacts --consumer-app-version ${GITHUB_SHA} --branch ${GITHUB_BRANCH}
 
 can-i-deploy:
 	@echo "--- 🤝 Can I Deploy?"


### PR DESCRIPTION
## Summary

- Replaces the legacy `--tag ${GITHUB_BRANCH}` flag with `--branch ${GITHUB_BRANCH}` in the `publish` Makefile target.
- Aligns pact publishing with the broker's branch-based workflow, moving away from the deprecated tag-based approach.
- No functional logic changes — only the CLI flag passed to the Pact CLI is updated.

## Test plan

- [ ] Verify the `publish` Make target runs successfully in CI with the updated flag.
- [ ] Confirm pacts appear under the correct branch (not tag) in the Pact broker after publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)